### PR TITLE
Motion Smoothing disable guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Run Fallout 4 VR once and change setting:
   
   - TAA set to ON
   
-  - Turn Off [Motion Smoothing](https://steamcommunity.com/app/250820/discussions/0/2251182852569611901/) in SteamVR.
+  - Turn Off [Motion Smoothing](https://steamcommunity.com/app/250820/discussions/0/2251182852569611901/) in SteamVR. If you are not using a Valve headset, use [one of these](motion-smoothing.md) methods for your platform.
+
 
 If you haven't to played the intro/tutorial, now would be a good time to do that. (Don't think too much what you put on your skills, we'll gonna do that for real later.)
 

--- a/motion-smoothing.md
+++ b/motion-smoothing.md
@@ -14,10 +14,10 @@ To disable Motion Smoothing on different VR platforms than SteamVR, follow these
    - Scroll down to "Performance settings."
    - Toggle off "Motion Smoothing."
 
-## 2. Oculus Quest (Using Oculus Link for PC VR)
+## 2. Meta Quest (Using Meta Quest Link for PC VR)
 
-1. **Open Oculus Software on PC:**
-   - Launch the Oculus software on your PC.
+1. **Open Meta Quest Link Software on PC:**
+   - Launch the Meta Quest Link software on your PC.
 
 2. **Access Settings:**
    - Click on "Devices" in the left sidebar.
@@ -25,7 +25,7 @@ To disable Motion Smoothing on different VR platforms than SteamVR, follow these
 
 3. **Graphics Preferences:**
    - Go to "Graphics Preferences."
-   - Here, you can adjust settings related to ASW (Asynchronous SpaceWarp) which is Oculus' motion smoothing technology.
+   - Here, you can adjust settings related to ASW (Asynchronous SpaceWarp) which is Meta's motion smoothing technology.
    - Set it to "Off" or customize it according to your preference.
 
 4. **Using Oculus Debug Tool:**

--- a/motion-smoothing.md
+++ b/motion-smoothing.md
@@ -1,0 +1,34 @@
+To disable Motion Smoothing on different VR platforms than SteamVR, follow these steps.
+
+## 1. Windows Mixed Reality
+
+1. **Open Mixed Reality Portal:**
+   - Launch the Mixed Reality Portal from your Start menu.
+
+2. **Access Settings:**
+   - Click on the menu (three horizontal lines) in the top-left corner.
+   - Select "Settings."
+
+3. **Turn Off Motion Smoothing:**
+   - Navigate to the "Headset display" tab.
+   - Scroll down to "Performance settings."
+   - Toggle off "Motion Smoothing."
+
+## 2. Oculus Quest (Using Oculus Link for PC VR)
+
+1. **Open Oculus Software on PC:**
+   - Launch the Oculus software on your PC.
+
+2. **Access Settings:**
+   - Click on "Devices" in the left sidebar.
+   - Select your connected Quest headset.
+
+3. **Graphics Preferences:**
+   - Go to "Graphics Preferences."
+   - Here, you can adjust settings related to ASW (Asynchronous SpaceWarp) which is Oculus' motion smoothing technology.
+   - Set it to "Off" or customize it according to your preference.
+
+4. **Using Oculus Debug Tool:**
+   - Navigate to the Oculus installation directory (usually `C:\Program Files\Oculus\Support\oculus-diagnostics`).
+   - Open "OculusDebugTool.exe."
+   - Find the "Asynchronous Spacewarp" setting and set it to "Disabled."


### PR DESCRIPTION
I use Meta Quest Link and noticed that there were no guides on how to disable Motion Smoothing for other platforms than Valve headsets. I added some simple ones as well as an alternative method for the Quest.